### PR TITLE
Implement a case-related activity change trigger

### DIFF
--- a/CRM/Civirules/Upgrader.php
+++ b/CRM/Civirules/Upgrader.php
@@ -155,4 +155,15 @@ class CRM_Civirules_Upgrader extends CRM_Civirules_Upgrader_Base {
     );
     return true;
   }
+
+  /**
+   * Update to insert the trigger for Case Activity changed
+   */
+  public function upgrade_1010() {
+    CRM_Core_DAO::executeQuery("
+      INSERT INTO civirule_trigger (name, label, object_name, op, class_name, created_date, created_user_id)
+      VALUES ('changed_case_activity', 'Case activity is changed', 'Activity', 'edit', 'CRM_CivirulesPostTrigger_CaseActivity', CURDATE(), 1);"
+    );
+    return TRUE;
+  }
 }

--- a/CRM/CivirulesPostTrigger/CaseActivity.php
+++ b/CRM/CivirulesPostTrigger/CaseActivity.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Trigger when an Activity linked to a Case changes.
+ *
+ * Notice: this class extends from CRM_CivirulesPostTrigger_Activity
+ * (trigger on Activity change). By doing this, we reuse all the
+ * Activity triggering logic, while still filtering for Case-related
+ * activities.
+ */
+class CRM_CivirulesPostTrigger_CaseActivity extends CRM_CivirulesPostTrigger_Activity {
+
+  /**
+   * Override getTriggerDataFromPost() so that we can append the Case
+   * entity to the trigger data.
+   */
+  protected function getTriggerDataFromPost($op, $objectName, $objectId, $objectRef) {
+    $triggerData = parent::getTriggerDataFromPost($op, $objectName,
+                                                  $objectId, $objectRef);
+
+
+    // Get the CaseActivity record.
+    $caseActivity = new CRM_Case_DAO_CaseActivity();
+    $caseActivity->activity_id = $objectId;
+    if (!$caseActivity->find(TRUE)) {
+      return $triggerData;
+    }
+
+    // Now load the case.
+    $case = new CRM_Case_BAO_Case();
+    $case->id = $caseActivity->case_id;
+    if (!$case->find(TRUE)) {
+      return $triggerData;
+    }
+
+    $data = array();
+    CRM_Core_DAO::storeValues($case, $data);
+    $triggerData->setEntityData('Case', $data);
+
+    return $triggerData;
+  }
+
+
+  /**
+   * Trigger a rule for this trigger
+   *
+   * @param $op
+   * @param $objectName
+   * @param $objectId
+   * @param $objectRef
+   */
+  public function triggerTrigger($op, $objectName, $objectId, $objectRef) {
+    if (CRM_Case_BAO_Case::isCaseActivity($objectId)) {
+      // It is a Case-related activity -- let our parent trigger
+      // actually trigger the rule.
+      parent::triggerTrigger($op, $objectName, $objectId, $objectRef);
+    }
+  }
+
+
+  /**
+   * Returns additional entities provided in this trigger.
+   *
+   * @return array of CRM_Civirules_TriggerData_EntityDefinition
+   */
+  protected function getAdditionalEntities() {
+    $entities = parent::getAdditionalEntities();
+    $entities[] = new CRM_Civirules_TriggerData_EntityDefinition('Case', 'Case', 'CRM_Case_DAO_Case' , 'Case');
+    return $entities;
+  }
+}

--- a/sql/insertCiviruleTrigger.sql
+++ b/sql/insertCiviruleTrigger.sql
@@ -83,11 +83,11 @@ VALUES
   ('deleted_relationship', 'Relationship is deleted', 'Relationship', 'delete', 'CRM_CivirulesPostTrigger_Relationship', CURDATE(), 1),
   ('new_tag', 'Tag is added', 'Tag', 'create', null,  CURDATE(), 1),
   ('changed_tag', 'Tag is changed', 'Tag', 'edit', null, CURDATE(), 1),
-  ('deleted_tag', 'Tag is deleted', 'Tag', 'delete', null, CURDATE(), 1);
+  ('deleted_tag', 'Tag is deleted', 'Tag', 'delete', null, CURDATE(), 1),
+  ('changed_case_activity', 'Case activity is changed', 'Activity', 'edit', 'CRM_CivirulesPostTrigger_CaseActivity', CURDATE(), 1);
 
 INSERT INTO civirule_trigger (name, label, object_name, op, cron, class_name, created_date, created_user_id)
 VALUES
   ('birthday', 'Individual has birthday', null, null, 1, 'CRM_CivirulesCronTrigger_Birthday',  CURDATE(), 1),
   ('groupmembership', 'Daily trigger for group members', null, null, 1, 'CRM_CivirulesCronTrigger_GroupMembership',  CURDATE(), 1),
   ('activitydate', 'Activity Date reached', null, null, 1, 'CRM_CivirulesCronTrigger_ActivityDate',  CURDATE(), 1);
-


### PR DESCRIPTION
This patch implements a case-related activity change trigger, to allow workflows based on activities that are related to cases.

Notice that this new trigger leverages the Activity trigger class by inheriting it.