### PR TITLE
Get original comparison value use the wrong operator. And the operato…

### DIFF
--- a/CRM/CivirulesConditions/Generic/FieldValueChangeComparison.php
+++ b/CRM/CivirulesConditions/Generic/FieldValueChangeComparison.php
@@ -20,13 +20,14 @@ abstract class CRM_CivirulesConditions_Generic_FieldValueChangeComparison extend
    * @access protected
    */
   protected function getOriginalComparisonValue() {
-    switch ($this->getOperator()) {
+    switch ($this->getOriginalOperator()) {
       case '=':
       case '!=':
       case '>':
       case '>=':
       case '<':
       case '<=':
+      case 'contains string':
         $key = 'original_value';
         break;
       case 'is one of':
@@ -60,6 +61,7 @@ abstract class CRM_CivirulesConditions_Generic_FieldValueChangeComparison extend
       case '>=':
       case '<':
       case '<=':
+      case 'contains string':
         $key = 'value';
         break;
       case 'is one of':


### PR DESCRIPTION
Issue: #105 
Get original comparison value use the wrong operator. And the operator "contains string" is missing