### PR TITLE
Remove invalid argument warning from count()

### DIFF
--- a/CRM/Civirules/Form/Rule.php
+++ b/CRM/Civirules/Form/Rule.php
@@ -471,12 +471,14 @@ class CRM_Civirules_Form_Rule extends CRM_Core_Form {
     $this->ruleId = $savedRule['id'];
     // first delete all tags for the rule if required then save new ones
     CRM_Civirules_BAO_RuleTag::deleteWithRuleId($this->ruleId);
-    foreach ($formValues['rule_tag_id'] as $ruleTagId) {
-      $ruleTagParams = array(
-        'rule_id' => $this->ruleId,
-        'rule_tag_id' => $ruleTagId
-      );
-      CRM_Civirules_BAO_RuleTag::add($ruleTagParams);
+    if (isset($formValues['rule_tag_id'])) {
+      foreach ($formValues['rule_tag_id'] as $ruleTagId) {
+        $ruleTagParams = array(
+          'rule_id' => $this->ruleId,
+          'rule_tag_id' => $ruleTagId
+        );
+        CRM_Civirules_BAO_RuleTag::add($ruleTagParams);
+      }
     }
   }
 

--- a/CRM/Civirules/Form/Search/Rules.php
+++ b/CRM/Civirules/Form/Search/Rules.php
@@ -220,7 +220,7 @@ LEFT JOIN civicrm_contact contact ON crr.created_user_id = contact.id";
    * @return string
    */
   function count() {
-    return CRM_Core_DAO::singleValueQuery($this->sql('COUNT(DISTINCT(crr.id)) AS total'), 0, 0, NULL, FALSE, NULL);
+    return CRM_Core_DAO::singleValueQuery($this->sql('COUNT(DISTINCT(crr.id)) AS total'), array(), 0, NULL, FALSE, NULL);
   }
 
   /**


### PR DESCRIPTION
On a fresh installation of CiviRules, go to "Find Rules", press "Search", and you'll get this warning:
    Warning: Invalid argument supplied for foreach() in CRM_Core_DAO::composeQuery() (line 1370 of /home/jon/local/civicrm-buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/DAO.php).

This PR fixes that (an integer was passed where an array is necessary).