### PR TITLE
Using 'is empty' on a FieldValueChangeComparison Civirule Condition

### DIFF
--- a/CRM/CivirulesConditions/FieldValueComparison.php
+++ b/CRM/CivirulesConditions/FieldValueComparison.php
@@ -23,7 +23,7 @@ class CRM_CivirulesConditions_FieldValueComparison extends CRM_CivirulesConditio
     if (strpos($field, 'custom_')===0) {
       $custom_field_id = str_replace("custom_", "", $field);
       try {
-        $params['entityID'] = $data['id'];
+        $params['entityID'] = (isset($data['id']) ? $data['id'] : null);
         $params[$field] = 1;
         $values = CRM_Core_BAO_CustomValueTable::getValues($params);
 

--- a/CRM/CivirulesConditions/Generic/FieldValueChangeComparison.php
+++ b/CRM/CivirulesConditions/Generic/FieldValueChangeComparison.php
@@ -40,7 +40,8 @@ abstract class CRM_CivirulesConditions_Generic_FieldValueChangeComparison extend
         break;
     }
 
-    if (!empty($this->conditionParams[$key])) {
+    if (isset($key)
+        and !empty($this->conditionParams[$key])) {
       return $this->conditionParams[$key];
     } else {
       return '';
@@ -74,7 +75,8 @@ abstract class CRM_CivirulesConditions_Generic_FieldValueChangeComparison extend
         break;
     }
 
-    if (!empty($this->conditionParams[$key])) {
+    if (isset($key)
+        and !empty($this->conditionParams[$key])) {
       return $this->conditionParams[$key];
     } else {
       return '';

--- a/templates/CRM/CivirulesConditions/Form/FieldValueChangeComparison.tpl
+++ b/templates/CRM/CivirulesConditions/Form/FieldValueChangeComparison.tpl
@@ -84,6 +84,11 @@
                     cj('#original_multi_value_parent').removeClass('hiddenElement');
                     cj('#original_value_parent').addClass('hiddenElement');
                     break;
+               case 'is empty':
+               case 'is not empty':
+                   cj('#original_multi_value_parent').addClass('hiddenElement');
+                   cj('#original_value_parent').addClass('hiddenElement');
+                   break;
                 default:
                     cj('#original_multi_value_parent').addClass('hiddenElement');
                     cj('#original_value_parent').removeClass('hiddenElement');


### PR DESCRIPTION
- Fixes some notices

- in the form, when chosing 'is empty'
the field for 'the value to compare to' is hidden for the orginal value,
the same way as for the new value