### PR TITLE
All membership types

### DIFF
--- a/CRM/Civirules/Utils.php
+++ b/CRM/Civirules/Utils.php
@@ -260,6 +260,7 @@ class CRM_Civirules_Utils {
     } else {
       $params = array();
     }
+    $params['options'] = array('limit' => 0, 'sort' => "name ASC");
     try {
       $membershipTypes = civicrm_api3("MembershipType", "Get", $params);
       foreach ($membershipTypes['values'] as $membershipType) {

--- a/CRM/CivirulesConditions/Membership/ActiveMembership.php
+++ b/CRM/CivirulesConditions/Membership/ActiveMembership.php
@@ -44,8 +44,12 @@ class CRM_CivirulesConditions_Membership_ActiveMembership extends CRM_Civirules_
    * @access public
    */
   public function userFriendlyConditionParams() {
+    $params = array(
+      'is_active' => 1,
+       'options' => array('limit' => 0, 'sort' => "name ASC"),
+    );
     try {
-      $membershipTypes = civicrm_api3('MembershipType', 'Get', array('is_active' => 1));
+      $membershipTypes = civicrm_api3('MembershipType', 'Get', $params);
       $operator = 'equals';
       foreach ($membershipTypes['values'] as $membershipType) {
         if ($membershipType['id'] == $this->conditionParams['membership_type_id']) {

--- a/CRM/CivirulesConditions/Membership/Type.php
+++ b/CRM/CivirulesConditions/Membership/Type.php
@@ -69,7 +69,7 @@ class CRM_CivirulesConditions_Membership_Type extends CRM_Civirules_Condition {
       $params = array(
         'is_active' => 1,
         'options' => array('limit' => 0, 'sort' => "name ASC"),
-      ));
+      );
       $membershipTypes = civicrm_api3('MembershipType', 'Get', $params);
       $operator = null;
       if ($this->conditionParams['operator'] == 0) {

--- a/CRM/CivirulesConditions/Membership/Type.php
+++ b/CRM/CivirulesConditions/Membership/Type.php
@@ -66,7 +66,11 @@ class CRM_CivirulesConditions_Membership_Type extends CRM_Civirules_Condition {
    */
   public function userFriendlyConditionParams() {
     try {
-      $membershipTypes = civicrm_api3('MembershipType', 'Get', array('is_active' => 1));
+      $params = array(
+        'is_active' => 1,
+        'options' => array('limit' => 0, 'sort' => "name ASC"),
+      ));
+      $membershipTypes = civicrm_api3('MembershipType', 'Get', $params);
       $operator = null;
       if ($this->conditionParams['operator'] == 0) {
         $operator = 'equals';

--- a/CRM/CivirulesConditions/Membership/Type.php
+++ b/CRM/CivirulesConditions/Membership/Type.php
@@ -65,11 +65,11 @@ class CRM_CivirulesConditions_Membership_Type extends CRM_Civirules_Condition {
    * @access public
    */
   public function userFriendlyConditionParams() {
+    $params = array(
+      'is_active' => 1,
+      'options' => array('limit' => 0, 'sort' => "name ASC"),
+    );
     try {
-      $params = array(
-        'is_active' => 1,
-        'options' => array('limit' => 0, 'sort' => "name ASC"),
-      );
       $membershipTypes = civicrm_api3('MembershipType', 'Get', $params);
       $operator = null;
       if ($this->conditionParams['operator'] == 0) {


### PR DESCRIPTION
The API has a limit of 25 entries by default.  This patch removes that limit so all membership types are returned via the API and can be selected in conditions.