### PR TITLE
Move CiviRules hooks docs into this repo (instead of Developer Guide)

### DIFF
--- a/docs/add-logging.md
+++ b/docs/add-logging.md
@@ -152,7 +152,7 @@ We are going to implement the methods in such a way that they are calling the lo
 ```
 ### Implement the actual log method
 
-The remaining bit of the class is to implement the `log` method in such a way that the log messages is shown as a popup to the user.
+The remaining bit of the class is to use [hook_civirules_logger](/hooks/hook_civirules_logger) implement the `log` method in such a way that the log messages is shown as a popup to the user.
 
 ```php
 function examplecivirulelogger_civirules_logger(\Psr\Log\LoggerInterface &$logger=null) {
@@ -188,15 +188,6 @@ In case of an error the following extra context parameters are available:
 - exception_message
 - file
 - line
-```
-## Hook hook_civirules_logger
-
-This hook is invoked as soon as CiviRules is looking for a logger class. It has one parameter and that is the current Logger, which probably is `null`. If you want to return a logger you should replace the `$logger` parameter with an instantiated logger object.
-
-```php
-function hook_civirules_logger(\Psr\Log\LoggerInterface &$logger=null) {
-  $logger = new CRM_Examplecivirulelogger_PopupLogger();
-}
 ```
 
 ## Adding a message to the Rule form

--- a/docs/add-logging.md
+++ b/docs/add-logging.md
@@ -10,9 +10,6 @@ With this in mind we could easily develop an extension which hooks the default C
     Why Not the Standard CiviCRM Logger?
     The reason we are not using the default CiviCRM logger is that in CiviCRM 4.4 there is no PSR3 logger implementation.
 
-!!! Note
-    In the code examples below the `<?php` tag on the start is added on behalf of the pretty formatting   
-
 By default Civirules will only send erros to the logger. Those errors are exceptions which are caught during processing of a CiviRule or during processing of a delayed CiviRule action.
 
 ### Tutorial log messages to screen
@@ -22,7 +19,6 @@ In the tutorial below we will implement a logger which logs the messages to the 
 The first step is achieved by developing an logger which implement the [PSR3 LoggerInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#3-psrlogloggerinterface).  
 
 ```php
-<?php
 //file CRM/Examplecivirulelogger/PopupLogger
 class CRM_Examplecivirulelogger_PopupLogger implements \Psr\Log\LoggerInterface {
 }
@@ -46,7 +42,6 @@ All methods have the same kind of structure which takes a message as a parameter
 We are going to implement the methods in such a way that they are calling the log method with the appropriate level.
 
 ```php
-<?php 
 /**
   * System is unusable.
   *
@@ -160,7 +155,6 @@ We are going to implement the methods in such a way that they are calling the lo
 The remaining bit of the class is to implement the `log` method in such a way that the log messages is shown as a popup to the user.
 
 ```php
-<?php
 function examplecivirulelogger_civirules_logger(\Psr\Log\LoggerInterface &$logger=null) {
   $logger = new CRM_Examplecivirulelogger_PopupLogger();
 }
@@ -200,7 +194,6 @@ In case of an error the following extra context parameters are available:
 This hook is invoked as soon as CiviRules is looking for a logger class. It has one parameter and that is the current Logger, which probably is `null`. If you want to return a logger you should replace the `$logger` parameter with an instantiated logger object.
 
 ```php
-<?php
 function hook_civirules_logger(\Psr\Log\LoggerInterface &$logger=null) {
   $logger = new CRM_Examplecivirulelogger_PopupLogger();
 }
@@ -213,7 +206,6 @@ If you want to add contents to the rule form. E.g. enable logging for that parti
 <a href='../img/screenshot_civirules_civirule_form.png'><img alt='my group setup' src='../img/screenshot_civirules_civirule_form.png'/></a>
 
 ```php
-<?php
 function examplecivirulelogger_civicrm_buildForm($formName, &$form) {
   if ($form instanceof CRM_Civirules_Form_Rule) {
     $form->setPostRuleBlock("Logging is enabled");
@@ -226,8 +218,8 @@ function examplecivirulelogger_civicrm_buildForm($formName, &$form) {
 If you have developed a CiviRules action or condition you can send messages to the logger:
 
 __Logging from a CiviRules action__
+
 ```php
-<?php
 public function processAction(CRM_Civirules_TriggerData_TriggerData $triggerData){
   $this->logAction('my log message', $triggerData, \PSR\Log\LogLevel::INFO);
   ...
@@ -235,8 +227,8 @@ public function processAction(CRM_Civirules_TriggerData_TriggerData $triggerData
 ```
 
 __Logging from a CiviRules condition__
+
 ```php
-<?php
 public function isConditionValid(CRM_Civirules_TriggerData_TriggerData $triggerData){
   $this->logCondition('my log message', $triggerData, \PSR\Log\LogLevel::INFO);
   ...

--- a/docs/create-your-own-action.md
+++ b/docs/create-your-own-action.md
@@ -25,8 +25,6 @@ You need to make sure that there is a record in the civirule_action table for yo
 If you have created your extension with Civix then you can add a file `CRM/CivirulesAction/Contact/SoftDelete.mgd.php`. If you didn't create your extension with civix you should add the `hook_civicrm_managed_entities` to your extension and return the array below. The parameter _class_name_ (linked to the column class_name in the table) should hold the name of the class you are going to create in step 2. So it could be anything you think useful, in the example we will stick to `CRM_CiviRulesActions_Contact_SoftDelete`
 
 ```php
-<?php
- 
 return array (
   0 =>
     array (
@@ -43,6 +41,7 @@ return array (
     ),
 );
 ```
+
 !!! Note
     You can also use the API to add an Action to CiviRules. Entity is `CiviRuleAction`, action is `Create`.
 
@@ -125,8 +124,6 @@ You need to make sure that there is a record in the civirule_action table for yo
 If you have created your extension with Civix then you can add a file `CRM/CivirulesAction/Contact/Subtype.mgd.php`. If you didn't create your extension with civix you should add the `hook_civicrm_managed_entities` to your extension and return the array below. The parameter `class_name` (linked to the column `class_name` in the table) should hold the name of the class you are going to create in step 2. So it could be anything you think useful, in the example we will stick to `CRM_CiviRulesActions_Contact_Subtype`.
 
 ```php
-<?php
- 
 return array (
   0 =>
     array (
@@ -155,7 +152,6 @@ I create a PHP class called  <whatever namespace I like>, so in this example tha
 If you are using an IDE (I use PhpStorm) you might get errors telling you class must be defined abstract or implement methods `processAction`and `getExtraDataInputUrl`. If that is the case, you will get the answers in step 3.
 
 ```php
-<?php
 class CRM_CivirulesActions_Contact_Subtype extends CRM_Civirules_Action {
 ```
 
@@ -168,7 +164,6 @@ class CRM_CivirulesActions_Contact_Subtype extends CRM_Civirules_Action {
 Method `getExtraDataInputUrl` can be used if you have additional forms for your action like in this example. If you do not need it, you can simply return `FALSE`. The method receives the parameter `ruleActionId`. Obviously I will have to generate my form separately, and make sure that the url I include in this method is actually pointing to my form. In code for this example:
 
 ```php
-<?php
 /**
  * Method to return the url for additional form processing for action
  * and return false if none is needed
@@ -184,7 +179,6 @@ public function getExtraDataInputUrl($ruleActionId) {
 Method `processAction` is called in the CiviRules engine to execute whatever your action needs to do. It needs to receive a parameter `triggerData` that will be passed in with the object of the class `CRM_Civirules_TriggerData_TriggerData`. Now you can do all sorts of complictated stuff in your `processAction`, or a simple basic API action. In this example we are setting the contact subtype(s) for a contact, and using the `CRM_Contact_BAO_Contact::add` method to do so. (We could also have used the API but that is no fun for this example).
 
 ```php
-<?php
 /**
  * Method processAction to execute the action
  *
@@ -224,7 +218,6 @@ To show the action paramaters in a reasonably nice format as shown in this scree
 I use the method `userFriendlyCondtionParams`:
 
 ```php
-<?php
 /**
  * Returns a user friendly text explaining the condition params
  * e.g. 'Older than 65'
@@ -298,7 +291,6 @@ I now only need to create the form used to select the contact subtype. I will cr
 and the code like this. Note that I am extending the `CRM_CivirulesActionss_Form_Form` class which already does most of the CiviRules Engine stuff for me.
 
 ```php
-<?php
 /**
  * Class for CiviRules Group Contact Action Form
  *
@@ -430,8 +422,6 @@ In this tutorial I will explain how to use the API when you are adding a CiviRul
 The CiviRules extension has a class `CRM_CiviRulesActions_Generic_Api` which allows you to add a CiviRule action for an API Entity/Action very quickly. The class itself looks like this:
 
 ```php
-<?php
- 
 abstract class CRM_CivirulesActions_Generic_Api extends CRM_Civirules_Action {
  
   /**
@@ -521,7 +511,6 @@ If you in your code extend this class you basically only need to use a couple of
 So this could be enough to construct a valid CiviRule action:
 
 ```php
-<?php
 /**
  * Class for CiviRules Set Thank You Date for Contribution Action
  *

--- a/docs/create-your-own-condition.md
+++ b/docs/create-your-own-condition.md
@@ -34,7 +34,6 @@ You need to make sure that there is a record in the civirule_condition table for
 If you have created your extension with Civix then you can add a file `CRM/CivirulesConditions/FirstDonation.mgd.php`. If you didn't create your extension with civix you should add the `hook_civicrm_managed_entities` to your extension and return the array below. The parameter _class_name_ (linked to the column class_name in the table) should hold the name of the class you are going to create in step 2. So it could be anything you think useful, in the example we will stick to `CRM_CiviRulesConditions_Contribution_FirstDonation`.   
 
 ```php
-<?php
 return array (
   0 =>
     array (
@@ -62,7 +61,6 @@ I create a PHP class called  <whatever namespace I like>, so in this example tha
 If you are using an IDE (I use PhpStorm) you might get errors telling you class must be defined abstract or implement methods `isConditionValid` and `getExtraDataInputUrl`. If that is the case, you will get the answers in step 3.    
 
 ```php
-<?php
 class CRM_CivirulesConditions_Contribution_FirstDonation extends CRM_Civirules_Condition {
 ```
 
@@ -78,7 +76,6 @@ There are 2 mandatory methods that you need to implement in your class: `getExtr
 Method `getExtraDataInputUrl` is used if you have additional forms for your condition, as is the case now. In this method you pass the url of the form you have created. The CiviRules Engine will pass control to this form when appropriate and make sure that the userContext to return to is in CiviRules. You will have to pass the rule_condition_id to the form url.
 
 ```php
-<?php
 /**
  * Returns a redirect url to extra data input from the user after adding a condition
  *
@@ -104,7 +101,6 @@ So in this example I will get the contact_id of the event with the $triggerData-
     I check if there is more than 1 contribution because the Trigger is triggered in the CiviCRM post hook, so I already have one contribution, which is the first one.
 
 ```php
-<?php
 /**
  * Method is mandatory and checks if the condition is met
  *
@@ -145,7 +141,6 @@ If I use this condition, it only makes sense if I add this condition to Triggers
 The user interface of CiviRules has the ability to check if you tell it what entity you need for your condition. In this example I need data from the entity Contribution, so I add Contribution with the method `requiredEntities` like this:
 
 ```php
-<?php
 /**
  * Returns an array with required entity names
  *
@@ -184,7 +179,6 @@ You need to make sure that there is a record in the civirule_condition table for
 If you have created your extension with Civix then you can add a file `CRM/CivirulesConditions/FirstDonation.mgd.php`. If you didn't create your extension with civix you should add the `hook_civicrm_managed_entities` to your extension and return the array below. The parameter `class_name` (linked to the column class_name in the table) should hold the name of the class you are going to create in step 2. So it could be anything you think useful, in the example we will stick to `CRM_CiviRulesConditions_Membership_Type`.    
 
 ```php
-<?php
  return array (
   0 =>
     array (
@@ -211,7 +205,6 @@ I create a PHP class called  `<whatever namespace I like>`, so in this example t
 If you are using an IDE (I use PhpStorm) you might get errors telling you class must be defined abstract or implement methods `isConditionValid` and `getExtraDataInputUrl`. If that is the case, you will get the answers in step 3.    
 
 ```php
-<?php
 class CRM_CivirulesConditions_Membership_Type extends CRM_Civirules_Condition {
 ```
 
@@ -225,7 +218,6 @@ There are 2 mandatory methods that you need to implement in your class: `getExtr
 Method `getExtraDataInputUrl` is used if you have additional forms for your condition, as is the case now. In this method you pass the url of the form you have created. The CiviRules Engine will pass control to this form when appropriate and make sure that the userContext to return to is in CiviRules. You will have to pass the `rule_condition_id` to the form url.    
 
 ```php
-<?php
 /**
  * Returns a redirect url to extra data input from the user after adding a condition
  *
@@ -249,7 +241,6 @@ The method should return `TRUE` or `FALSE`.
 So in this example I will get the `membership_type_id` of the entity Membership (to which condition will be linked to make any sense) and compare it to the one in the condition parameters, like so:
 
 ```php
-<?php
 /**
  * Method to determine if the condition is valid
  *
@@ -299,7 +290,6 @@ public function requiredEntities() {
 Storing the condition parameters in the database is done with the method `setRuleConditionData` like this:
 
 ```php
-<?php
 /**
  * Method to set the Rule Condition data
  *
@@ -324,7 +314,6 @@ To show the condition paramaters in a reasonably nice format as shown in this sc
 I use the method userFriendlyConditionParams:
 
 ```php
-<?php
 /**
  * Returns a user friendly text explaining the condition params
  * e.g. 'Older than 65'
@@ -378,7 +367,6 @@ I now only need to create the form used to select the membership type. I will cr
 and the code like this. Note that I am extending the CRM_CivirulesConditions_Form_Form class which already does most of the CiviRules Engine stuff for me.
 
 ```php
-<?php
 /**
  * Class for CiviRules Condition Membership Type Form
  *

--- a/docs/create-your-own-delay.md
+++ b/docs/create-your-own-delay.md
@@ -33,8 +33,6 @@ Initially a couple of delays were added:
 It is quite easy to add delays by extending the class `CRM_Civirules_Delay_Delay`. Here is the example of the minutes delay:
 
 ```php
-<?php
- 
 class CRM_Civirules_Delay_XMinutes extends CRM_Civirules_Delay_Delay {
  
   protected $minuteOffset;

--- a/docs/create-your-own-introduction.md
+++ b/docs/create-your-own-introduction.md
@@ -28,6 +28,3 @@ Find more detailed information in the tutorials:
 - [Create your own condition](create-your-own-condition)
 - [Create your own action](create-your-own-action)
 - [Add logging](add-logging)
-
-!!! Remark
-    The tutorials are clarified with code fragments. To create nicer formatting in `mkdocs` these start often with a `<?php` that maybe obsolete in real use.

--- a/docs/hooks/hook_civirules_alter_trigger_data.md
+++ b/docs/hooks/hook_civirules_alter_trigger_data.md
@@ -1,0 +1,31 @@
+# hook_civirules_alter_trigger_data
+
+## Description
+
+This hook is called for altering the trigger data object just before a
+trigger is triggered.
+
+## Definition
+
+    hook_civirules_alter_trigger_data(CRM_Civirules_TriggerData_TriggerData &$triggerData )
+
+## Returns
+
+-   null
+
+## Example
+
+
+
+    /**
+    * Implements hook_civirules_alter_trigger_data
+    *
+    * Adds custom data to the trigger data object
+    */
+    function civirules_civirules_alter_trigger_data(CRM_Civirules_TriggerData_TriggerData &$triggerData) {
+
+      //also add the custom data which is passed to the pre hook (and not the post)
+
+      CRM_Civirules_Utils_CustomDataFromPre::addCustomDataToTriggerData($triggerData);
+
+    }

--- a/docs/hooks/hook_civirules_alter_trigger_data.md
+++ b/docs/hooks/hook_civirules_alter_trigger_data.md
@@ -7,25 +7,21 @@ trigger is triggered.
 
 ## Definition
 
-    hook_civirules_alter_trigger_data(CRM_Civirules_TriggerData_TriggerData &$triggerData )
+```php
+hook_civirules_alter_trigger_data(CRM_Civirules_TriggerData_TriggerData &$triggerData)
+```
 
 ## Returns
 
--   null
+-   `NULL`
 
 ## Example
 
+The example below adds custom data to the trigger data object.
 
-
-    /**
-    * Implements hook_civirules_alter_trigger_data
-    *
-    * Adds custom data to the trigger data object
-    */
-    function civirules_civirules_alter_trigger_data(CRM_Civirules_TriggerData_TriggerData &$triggerData) {
-
-      //also add the custom data which is passed to the pre hook (and not the post)
-
-      CRM_Civirules_Utils_CustomDataFromPre::addCustomDataToTriggerData($triggerData);
-
-    }
+```php
+function civirules_civirules_alter_trigger_data(CRM_Civirules_TriggerData_TriggerData &$triggerData) {
+  //also add the custom data which is passed to the pre hook (and not the post)
+  CRM_Civirules_Utils_CustomDataFromPre::addCustomDataToTriggerData($triggerData);
+}
+```

--- a/docs/hooks/hook_civirules_logger.md
+++ b/docs/hooks/hook_civirules_logger.md
@@ -1,0 +1,25 @@
+# hook_civirules_logger
+
+## Description
+
+This hook is called for return an object to do logging in CiviRules. The
+object should be instance of \Psr\Log\LoggerInterface or null if you
+want to disable the logging
+
+## Definition
+
+    hook_civirules_logger(\Psr\Log\LoggerInterface &$logger=null)
+
+## Returns
+
+-   null
+
+## Example
+
+The example below returns a database logger for civirules.
+
+    function civiruleslogger_civirules_logger(\Psr\Log\LoggerInterface &$logger=null) {
+      if (empty($logger)) {
+        $logger = new CRM_Civiruleslogger_DatabaseLogger();
+      }
+    }

--- a/docs/hooks/hook_civirules_logger.md
+++ b/docs/hooks/hook_civirules_logger.md
@@ -2,15 +2,23 @@
 
 ## Description
 
-This hook is called for return an object to do logging in CiviRules. The
-object should be instance of `\Psr\Log\LoggerInterface` or `null` if you
-want to disable the logging
+This hook is called for returning an object to do logging in CiviRules.
+It is invoked as soon as CiviRules is looking for a logger class.
+
+If you want to return a logger you should replace the `$logger` parameter with an instantiated logger object which should be instance of `\Psr\Log\LoggerInterface`.
+
+Set `$logger` to `null` if you want to disable the logging.
 
 ## Definition
 
 ```php
 hook_civirules_logger(\Psr\Log\LoggerInterface &$logger=null)
 ```
+
+## Parameters
+
+It has one parameter and that is the current Logger, which probably is `null`.
+
 
 ## Returns
 

--- a/docs/hooks/hook_civirules_logger.md
+++ b/docs/hooks/hook_civirules_logger.md
@@ -3,23 +3,27 @@
 ## Description
 
 This hook is called for return an object to do logging in CiviRules. The
-object should be instance of \Psr\Log\LoggerInterface or null if you
+object should be instance of `\Psr\Log\LoggerInterface` or `null` if you
 want to disable the logging
 
 ## Definition
 
-    hook_civirules_logger(\Psr\Log\LoggerInterface &$logger=null)
+```php
+hook_civirules_logger(\Psr\Log\LoggerInterface &$logger=null)
+```
 
 ## Returns
 
--   null
+-   `NULL`
 
 ## Example
 
 The example below returns a database logger for civirules.
 
-    function civiruleslogger_civirules_logger(\Psr\Log\LoggerInterface &$logger=null) {
-      if (empty($logger)) {
-        $logger = new CRM_Civiruleslogger_DatabaseLogger();
-      }
-    }
+```php
+function civiruleslogger_civirules_logger(\Psr\Log\LoggerInterface &$logger=null) {
+  if (empty($logger)) {
+    $logger = new CRM_Civiruleslogger_DatabaseLogger();
+  }
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,9 @@ pages:
   - Create your own condition: create-your-own-condition.md
   - Create your own action: create-your-own-action.md
   - Add logging: add-logging.md
+- Hooks:
+  - hook_civirules_alter_trigger_data: hooks/hook_civirules_alter_trigger_data.md
+  - hook_civirules_logger: hooks/hook_civirules_logger.md
 
 markdown_extensions:
   - attr_list

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,14 +22,24 @@ pages:
   - hook_civirules_alter_trigger_data: hooks/hook_civirules_alter_trigger_data.md
   - hook_civirules_logger: hooks/hook_civirules_logger.md
 
+
 markdown_extensions:
   - attr_list
   - admonition
   - def_list
-  - codehilite
-  - toc(permalink=true)
-  - pymdownx.superfences
-  - pymdownx.inlinehilite
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      guess_lang: true
+      extend_pygments_lang:
+        - name: php
+          lang: php
+          options:
+            startinline: true
+  - pymdownx.superfences:
+      css_class: codehilite
+  - pymdownx.inlinehilite:
+      css_class: codehilite
   - pymdownx.tilde
   - pymdownx.betterem
   - pymdownx.mark


### PR DESCRIPTION
## Motivation

The [Developer Guide](https://docs.civicrm.org/dev/en/latest/) currently contains documentation [here](https://docs.civicrm.org/dev/en/latest/hooks/hook_civirules_alter_trigger_data/) and [here](https://docs.civicrm.org/dev/en/latest/hooks/hook_civirules_logger/) about CiviRules hooks. This docs came through as part of the automated hook migration from the wiki. Now that we have a dedicated [CiviRules Guide](https://docs.civicrm.org/civirules/en/latest), I'd like to move those hooks docs out of the Dev Guide since they're extension-specific. 

## Before

* This repo contained only partial documentation on the hooks that CiviRules defines. 
* (Unrelated) Syntax highlighting for PHP code blocks was done with `<?php` and a couple notes instructed readers to disregard these tags

## After

* Hooks docs have been copied into this repo
* New doc content is merged with existing doc content
* (Bonus) Syntax highlighting is improved for all PHP code blocks so that `<?php` no longer displays to readers


*(Once this PR is merged, I'll remove the hooks docs from the Dev Guide, as tracked in [this ticket](https://github.com/civicrm/civicrm-dev-docs/issues/183))*