### PR TITLE
Remove gender assumption

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,8 @@ __Actions__ that specify what is to happen if the trigger occurs and the conditi
 
 This guide has two parts each aimed at a different audience.
 
-- [Basic examples](basic-example-introduction) shows the CiviCRM administrator how he can configure CiviRules by means of a number of examples.
-- [Create your own](create-your-own-introduction) shows the CiviCRM developer how he can expand the extension by creating own triggers, delays, and actions. 
+- [Basic examples](basic-example-introduction) shows the CiviCRM administrator how she/he can configure CiviRules by means of a number of examples.
+- [Create your own](create-your-own-introduction) shows the CiviCRM developer how she/he can expand the extension by creating own triggers, delays, and actions. 
 
 ## CiviCRM versions
 


### PR DESCRIPTION
Sadly, CiviCRM like many things in the world of tech, appears to be failing to attract women developers. Although changing he to she/he will not in itself solve this problem it at least stops rubbing salt in the wound.