### PR TITLE
Fix display of navigation menu for extensions / shoreditch

### DIFF
--- a/civirules.php
+++ b/civirules.php
@@ -141,7 +141,7 @@ function civirules_civicrm_navigationMenu( &$params ) {
     'attributes' => array(
       'label' => 'CiviRules',
       'name' => 'CiviRules',
-      'url' => null,
+      'url' => 'http://#',
       'permission' => 'administer CiviCRM',
       'operator' => null,
       'separator' => null,


### PR DESCRIPTION
All standard top-level menu items have their URL set to "http://#" which means that an "a" tag is generated inside the "<li>".  Theming for shoreditch as well as the accessible menu extension https://github.com/aydun/uk.squiffle.kam don't work properly if the "a" tag does not exist.  This PR fixes that and the menu works properly.