### PR TITLE
Use api for activity conditions instead of triggerdata

### DIFF
--- a/CRM/CivirulesConditions/Activity/Details.php
+++ b/CRM/CivirulesConditions/Activity/Details.php
@@ -37,7 +37,11 @@ class CRM_CivirulesConditions_Activity_Details extends CRM_Civirules_Condition {
    */
   public function isConditionValid(CRM_Civirules_TriggerData_TriggerData $triggerData) {
     $isConditionValid = FALSE;
-    $activity = $triggerData->getEntityData('Activity');
+    $activityData = $triggerData->getEntityData('Activity');
+    $activity = civicrm_api3('Activity', 'getsingle', array(
+      'return' => array("details"),
+      'id' => $activityData['id'],
+    ));
     switch ($this->conditionParams['operator']) {
       case 'exact_match':
         if (trim(strtolower($activity['details'])) == trim(strtolower($this->conditionParams['text']))) {

--- a/CRM/CivirulesConditions/Activity/Status.php
+++ b/CRM/CivirulesConditions/Activity/Status.php
@@ -37,7 +37,11 @@ class CRM_CivirulesConditions_Activity_Status extends CRM_Civirules_Condition {
    */
   public function isConditionValid(CRM_Civirules_TriggerData_TriggerData $triggerData) {
     $isConditionValid = FALSE;
-    $activity = $triggerData->getEntityData('Activity');
+    $activityData = $triggerData->getEntityData('Activity');
+    $activity = civicrm_api3('Activity', 'getsingle', array(
+      'return' => array("status_id"),
+      'id' => $activityData['id'],
+    ));
     switch ($this->conditionParams['operator']) {
       case 0:
         if (in_array($activity['status_id'], $this->conditionParams['status_id'])) {

--- a/CRM/CivirulesConditions/Activity/StatusChanged.php
+++ b/CRM/CivirulesConditions/Activity/StatusChanged.php
@@ -32,7 +32,11 @@ class CRM_CivirulesConditions_Activity_StatusChanged extends CRM_CivirulesCondit
   protected function getFieldValue(CRM_Civirules_TriggerData_TriggerData $triggerData) {
     $field = 'status_id';
 
-    $data = $triggerData->getEntityData('Activity');
+    $activityData = $triggerData->getEntityData('Activity');
+    $data = civicrm_api3('Activity', 'getsingle', array(
+      'return' => array($field),
+      'id' => $activityData['id'],
+    ));
     if (isset($data[$field])) {
       return $data[$field];
     }

--- a/CRM/CivirulesConditions/Activity/Type.php
+++ b/CRM/CivirulesConditions/Activity/Type.php
@@ -39,7 +39,11 @@ class CRM_CivirulesConditions_Activity_Type extends CRM_Civirules_Condition {
    */
   public function isConditionValid(CRM_Civirules_TriggerData_TriggerData $triggerData) {
     $isConditionValid = FALSE;
-    $activity = $triggerData->getEntityData('Activity');
+    $activityData = $triggerData->getEntityData('Activity');
+    $activity = civicrm_api3('Activity', 'getsingle', array(
+      'return' => array("activity_type_id"),
+      'id' => $activityData['id'],
+    ));
     switch ($this->conditionParams['operator']) {
       case 0:
         if (in_array($activity['activity_type_id'], $this->conditionParams['activity_type_id'])) {


### PR DESCRIPTION
Delayed actions recheck for activities should use current data.

Fixes #193 