### PR TITLE
Add condition UniqueAddress

### DIFF
--- a/CRM/CivirulesConditions/Address/UniqueAddress.mgd.php
+++ b/CRM/CivirulesConditions/Address/UniqueAddress.mgd.php
@@ -1,0 +1,17 @@
+<?php
+
+return array (
+  0 =>
+    array (
+      'name' => 'Civirules:Condition.UniqueAddress',
+      'entity' => 'CiviRuleCondition',
+      'params' =>
+        array (
+          'version' => 3,
+          'name' => 'address_is_unique',
+          'label' => 'Address is unique',
+          'class_name' => 'CRM_CivirulesConditions_UniqueAddress',
+          'is_active' => 1
+        ),
+    ),
+);

--- a/CRM/CivirulesConditions/Address/UniqueAddress.php
+++ b/CRM/CivirulesConditions/Address/UniqueAddress.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ *
+ * @author Daniël van Vuuren (hollandopensource.nl)
+ * @license http://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+class CRM_CivirulesConditions_UniqueAddress extends CRM_Civirules_Condition {
+
+  public function getExtraDataInputUrl($ruleConditionId) {
+    return FALSE;
+  }
+
+  /**
+   * Method to check if the condition is valid, will check if the address
+   * is unique
+   *
+   * @param CRM_Civirules_TriggerData_TriggerData $triggerData
+   * @return bool
+   * @access public
+   */
+  public function isConditionValid(CRM_Civirules_TriggerData_TriggerData $triggerData)
+  {
+    $uniqueAddressFields = array("street_address", "city", "state_province_id", "postal_code", "country_id");
+    $addressData = $triggerData->getEntityData('address');
+    $address = civicrm_api3('Address', 'getsingle', array(
+      'return' => $uniqueAddressFields,
+      'id' => $addressData['id'],
+    ));
+    if (!$address['is_error']) {
+      $addressCountParams = array();
+      foreach ($uniqueAddressFields as $field) {
+        $addressCountParams[$field] = $address[$field];
+      }
+      $addressCount = civicrm_api3('Address', 'getcount', $addressCountParams);
+      if ($addressCount == 1) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Returns an array with required entity names
+   *
+   * @return array
+   * @access public
+   */
+  public function requiredEntities() {
+    return array(
+      'Address',
+    );
+  }
+}


### PR DESCRIPTION
Returns true if the address has no duplicate in the database.
Returns false if the address no longer exists or if there are more of the same addresses.

The following fields are checked:
`$uniqueAddressFields = array("street_address", "city", "state_province_id", "postal_code", "country_id");`