### PR TITLE
[WIP] CATL-988: Add New Cron Trigger & Condition For Selecting Cases With No Activity For Specific Days

### DIFF
--- a/CRM/CivirulesConditions/Case/CaseActivity.mgd.php
+++ b/CRM/CivirulesConditions/Case/CaseActivity.mgd.php
@@ -1,0 +1,17 @@
+<?php
+
+return array (
+  0 =>
+    array (
+      'name' => 'Civirules:Condition.Case.CaseActivity',
+      'entity' => 'CiviRuleCondition',
+      'params' =>
+        array (
+          'version' => 3,
+          'name' => 'case_case_activity',
+          'label' => 'Days since last case activity',
+          'class_name' => 'CRM_CivirulesConditions_Case_CaseActivity',
+          'is_active' => 1
+        ),
+    ),
+);

--- a/CRM/CivirulesConditions/Case/CaseActivity.php
+++ b/CRM/CivirulesConditions/Case/CaseActivity.php
@@ -1,0 +1,80 @@
+<?php
+
+class CRM_CivirulesConditions_Case_CaseActivity extends CRM_Civirules_Condition {
+
+  private $conditionParams = array();
+
+  /**
+   * Method to set the Rule Condition data
+   *
+   * @param array $ruleCondition
+   * @access public
+   */
+  public function setRuleConditionData($ruleCondition) {
+    parent::setRuleConditionData($ruleCondition);
+    $this->conditionParams = array();
+    if (!empty($this->ruleCondition['condition_params'])) {
+      $this->conditionParams = unserialize($this->ruleCondition['condition_params']);
+    }
+  }
+
+  /**
+   * Method to determine if the condition is valid
+   *
+   * @param CRM_Civirules_TriggerData_TriggerData $triggerData
+   * @return bool
+   */
+  public function isConditionValid(CRM_Civirules_TriggerData_TriggerData $triggerData) {
+    $isConditionValid = FALSE;
+    $case = $triggerData->getEntityData('Case');
+    $daysInactive = $this->conditionParams['days_inactive'];
+
+    try {
+      $lastActivity = civicrm_api3('Activity', 'get', array(
+        'sequential' => 1,
+        'return' => array("modified_date"),
+        'case_id' => $case['id'],
+        'options' => array('sort' => "modified_date desc", 'limit' => 1),
+      ))['values'][0];
+    }
+    catch (Exception $e) {
+      return $isConditionValid;
+    }
+
+    $lastActivityDate = DateTime::createFromFormat("Y-m-d H:i:s", $lastActivity['modified_date']);
+    $today = new DateTime();
+    $diff = $today->diff($lastActivityDate)->format("%a");
+
+    if($diff >= $daysInactive) {
+      $isConditionValid = TRUE;
+    }
+
+    return $isConditionValid;
+  }
+
+  /**
+   * Returns a redirect url to extra data input from the user after adding a condition
+   *
+   * Return false if you do not need extra data input
+   *
+   * @param int $ruleConditionId
+   * @return bool|string
+   * @access public
+   * @abstract
+   */
+  public function getExtraDataInputUrl($ruleConditionId) {
+    return CRM_Utils_System::url('civicrm/civirule/form/condition/case/caseactivity', 'rule_condition_id='
+      .$ruleConditionId);
+  }
+
+  /**
+   * Returns an array with required entity names
+   *
+   * @return array
+   * @access public
+   */
+  public function requiredEntities() {
+    return array('Case');
+  }
+
+}

--- a/CRM/CivirulesConditions/Form/Case/CaseActivity.php
+++ b/CRM/CivirulesConditions/Form/Case/CaseActivity.php
@@ -1,0 +1,51 @@
+<?php
+
+class CRM_CivirulesConditions_Form_Case_CaseActivity extends CRM_CivirulesConditions_Form_Form {
+
+  protected function getCaseStatus() {
+    return CRM_CivirulesConditions_Case_CaseStatus::getCaseStatus();
+  }
+
+  /**
+   * Overridden parent method to build form
+   *
+   * @access public
+   */
+  public function buildQuickForm() {
+    $this->add('hidden', 'rule_condition_id');
+
+    $this->add('text', 'days_inactive', ts('Number of days'), array(), true);
+
+    $this->addButtons(array(
+      array('type' => 'next', 'name' => ts('Save'), 'isDefault' => TRUE,),
+      array('type' => 'cancel', 'name' => ts('Cancel'))));
+  }
+
+  /**
+   * Overridden parent method to set default values
+   *
+   * @return array $defaultValues
+   * @access public
+   */
+  public function setDefaultValues() {
+    $defaultValues = parent::setDefaultValues();
+    $data = unserialize($this->ruleCondition->condition_params);
+    if (!empty($data['days_inactive'])) {
+      $defaultValues['days_inactive'] = $data['days_inactive'];
+    }
+    return $defaultValues;
+  }
+
+  /**
+   * Overridden parent method to process form data after submission
+   *
+   * @throws Exception when rule condition not found
+   * @access public
+   */
+  public function postProcess() {
+    $data['days_inactive'] = $this->_submitValues['days_inactive'];
+    $this->ruleCondition->condition_params = serialize($data);
+    $this->ruleCondition->save();
+    parent::postProcess();
+  }
+}

--- a/CRM/CivirulesCronTrigger/CaseActivity.php
+++ b/CRM/CivirulesCronTrigger/CaseActivity.php
@@ -1,0 +1,53 @@
+<?php
+
+class CRM_CivirulesCronTrigger_CaseActivity extends CRM_Civirules_Trigger_Cron {
+
+  private $dao = false;
+
+  /**
+   * This function returns a CRM_Civirules_TriggerData_TriggerData this entity is used for triggering the rule
+   *
+   * Return false when no next entity is available
+   *
+   * @return CRM_Civirules_TriggerData_TriggerData|false
+   */
+  protected function getNextEntityTriggerData() {
+    if (!$this->dao) {
+      if (!$this->queryForTriggerEntities()) {
+        return false;
+      }
+    }
+    if ($this->dao->fetch()) {
+      $data = array();
+      CRM_Core_DAO::storeValues($this->dao, $data);
+      $triggerData = new CRM_Civirules_TriggerData_Cron(0, 'Case', $data);
+      return $triggerData;
+    }
+    return false;
+  }
+
+  /**
+   * Returns an array of entities on which the trigger reacts
+   *
+   * @return CRM_Civirules_TriggerData_EntityDefinition
+   */
+  protected function reactOnEntity() {
+    return new CRM_Civirules_TriggerData_EntityDefinition('Case', 'Case', 'CRM_Case_DAO_Case', 'Cases');
+  }
+
+  /**
+   * Method to query trigger entities
+   *
+   * @access private
+   */
+  private function queryForTriggerEntities() {
+
+    $sql = "SELECT c.*
+            FROM `civicrm_case` `c`
+            WHERE c.status_id = 1
+            ";
+    $this->dao = CRM_Core_DAO::executeQuery($sql, array(), true, 'CRM_Case_DAO_Case');
+
+    return true;
+  }
+}

--- a/sql/insertCiviruleTrigger.sql
+++ b/sql/insertCiviruleTrigger.sql
@@ -92,4 +92,5 @@ INSERT INTO civirule_trigger (name, label, object_name, op, cron, class_name, cr
 VALUES
   ('birthday', 'Individual has birthday', null, null, 1, 'CRM_CivirulesCronTrigger_Birthday',  CURDATE(), 1),
   ('groupmembership', 'Daily trigger for group members', null, null, 1, 'CRM_CivirulesCronTrigger_GroupMembership',  CURDATE(), 1),
-  ('activitydate', 'Activity Date reached', null, null, 1, 'CRM_CivirulesCronTrigger_ActivityDate',  CURDATE(), 1);
+  ('activitydate', 'Activity Date reached', null, null, 1, 'CRM_CivirulesCronTrigger_ActivityDate',  CURDATE(), 1),
+  ('caseactivity', 'Daily trigger for case activity', null, null, 1, 'CRM_CivirulesCronTrigger_CaseActivity',  CURDATE(), 1);

--- a/templates/CRM/CivirulesConditions/Form/Case/CaseActivity.tpl
+++ b/templates/CRM/CivirulesConditions/Form/Case/CaseActivity.tpl
@@ -1,0 +1,12 @@
+<h3>{$ruleConditionHeader}</h3>
+<div class="crm-block crm-form-block crm-civirule-rule_condition-block-case_activity">
+  <div class="crm-section">
+    <div class="label">{$form.days_inactive.label}</div>
+    <div class="content">{$form.days_inactive.html}</div>
+    <div class="description">If there is no activity in the case for this given number of days, this condition would result to TRUE.</div>
+    <div class="clear"></div>
+  </div>
+</div>
+<div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>

--- a/xml/Menu/civirules.xml
+++ b/xml/Menu/civirules.xml
@@ -106,6 +106,13 @@
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
   <item>
+    <path>civicrm/civirule/form/condition/case/caseactivity</path>
+    <page_callback>CRM_CivirulesConditions_Form_Case_CaseActivity</page_callback>
+    <title>case activity</title>
+    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
+  <item>
     <path>civicrm/civirule/form/condition/membershiptype</path>
     <page_callback>CRM_CivirulesConditions_Form_Membership_Type</page_callback>
     <title>membership type</title>


### PR DESCRIPTION
## Overview ##
The requirement was to be able to update case statuses of cases which do not have any activity for a certain number of days.
If on a case - the last activity recorded was more than a 'n' days ago - with this new rule - we should be able change the case status to a predefined value. 
As such in the configurations, the user will be able to add a rule for automatically changing the status of the case with respect to the last created date of an activity on the case. 

## Implementation ##
Screen 1:
civicrm/civirule/form/rule?reset=1&action=add
- Add a new cron trigger on civirules (extending CRM_Civirules_Trigger_Cron class) for 'Daily Trigger for case activity'
- The user could select this trigger from the dropdown
Screen 2:
civicrm/civirule/form/rule?action=update&id=rule_id
- This would show the new trigger added and the user can click on "add condition" to add a condition to this rule
Screen 3:
civicrm/civirule/form/rule_condition?reset=1&action=add&rid=rule_id
- Here the use can select the new condition "Number of days since last case activity"
Screen 4:
[custom-url]
- this would be a custom form page defined by the above new condition. Here the user can add the number of days since which the case did not have any new activity
Screen 5:
- Saving the above will bring the user to the same page as in Screen 2
- From here the user can add a new action by clicking on 'add action'
Screen 6:
civicrm/civirule/form/rule_action?reset=1&action=add&rule_id=rule_id
- The user can select the existing action "set a case status" and save
they can then select the new status they want the case to be updated to